### PR TITLE
Add explicit initialization for view model

### DIFF
--- a/osint_dork_builder/dork_builder/ui/main_window.py
+++ b/osint_dork_builder/dork_builder/ui/main_window.py
@@ -18,6 +18,7 @@ class MainWindow(QMainWindow):
         self._vm = vm
         self._setup_ui()
         self._wire_vm()
+        self._vm.initialize()
 
     def _setup_ui(self) -> None:
         central = QWidget(self)

--- a/osint_dork_builder/dork_builder/ui/viewmodels.py
+++ b/osint_dork_builder/dork_builder/ui/viewmodels.py
@@ -17,7 +17,10 @@ class AppViewModel(QObject):
         self._current_key: str | None = categories[0].key if categories else None
         self._checked: Set[int] = set()
         self._builder = QueryBuilder()
-        self.categories_changed.emit(categories)
+
+    def initialize(self) -> None:
+        """Emit initial state signals."""
+        self.categories_changed.emit(self._categories)
         if self._current_key:
             self.current_category_changed.emit(self._cat_by_key[self._current_key])
 


### PR DESCRIPTION
## Summary
- Add `initialize()` method to `AppViewModel` to emit startup signals
- Invoke `vm.initialize()` in `MainWindow` to populate UI after wiring

## Testing
- `python -m py_compile dork_builder/ui/viewmodels.py dork_builder/ui/main_window.py`


------
https://chatgpt.com/codex/tasks/task_e_689f2a24578c8327ba2b9511b659168b