### PR TITLE
feat: allow custom dorks

### DIFF
--- a/osint_dork_builder/app.py
+++ b/osint_dork_builder/app.py
@@ -8,8 +8,8 @@ from dork_builder.ui.main_window import MainWindow
 
 def main() -> int:
     app = QApplication(sys.argv)
-    categories = DorkRepository(SETTINGS.dorks_json_path).load()
-    vm = AppViewModel(categories)
+    repo = DorkRepository(SETTINGS.dorks_json_path)
+    vm = AppViewModel(repo)
     win = MainWindow(vm)
     win.show()
     return app.exec()

--- a/osint_dork_builder/dork_builder/core/repository.py
+++ b/osint_dork_builder/dork_builder/core/repository.py
@@ -30,3 +30,9 @@ class DorkRepository:
             clean = [x.strip() for x in items if isinstance(x, str) and x.strip()]
             cats.append(DorkCategory(key=key, label=label, items=clean))
         return cats
+
+    def save(self, categories: List[DorkCategory]) -> None:
+        data = {c.key: c.items for c in categories}
+        self.json_path.parent.mkdir(parents=True, exist_ok=True)
+        with self.json_path.open("w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)

--- a/osint_dork_builder/dork_builder/ui/main_window.py
+++ b/osint_dork_builder/dork_builder/ui/main_window.py
@@ -4,7 +4,7 @@ from PySide6.QtCore import Qt, Slot
 from PySide6.QtGui import QAction, QGuiApplication
 from PySide6.QtWidgets import (
     QWidget, QMainWindow, QListWidget, QListWidgetItem, QVBoxLayout, QHBoxLayout,
-    QPushButton, QLabel, QLineEdit, QMessageBox
+    QPushButton, QLabel, QLineEdit, QMessageBox, QInputDialog
 )
 from dork_builder.core.models import DorkCategory
 from dork_builder.core.commands import OpenInBrowserCommand, NoopCommand
@@ -31,11 +31,11 @@ class MainWindow(QMainWindow):
         self.lst_dorks.setSelectionMode(QListWidget.NoSelection)
 
         self.txt_preview = QLineEdit()
-        self.txt_preview.setReadOnly(True)
 
         self.btn_copy = QPushButton("Copy Query")
         self.btn_open = QPushButton("Open in Google")
         self.btn_clear = QPushButton("Clear")
+        self.btn_add = QPushButton("Add Dork")
 
         right_box = QVBoxLayout()
         right_box.addWidget(QLabel("Query Preview:"))
@@ -43,6 +43,7 @@ class MainWindow(QMainWindow):
         right_box.addWidget(self.btn_copy)
         right_box.addWidget(self.btn_open)
         right_box.addWidget(self.btn_clear)
+        right_box.addWidget(self.btn_add)
         right_box.addStretch(1)
 
         layout = QHBoxLayout(central)
@@ -61,7 +62,10 @@ class MainWindow(QMainWindow):
         self.btn_open.clicked.connect(lambda: self._open_cmd())
         self.btn_copy.clicked.connect(self._on_copy_clicked)
         self.btn_clear.clicked.connect(self._on_clear_clicked)
+        self.btn_add.clicked.connect(self._on_add_clicked)
         self.lst_dorks.itemChanged.connect(self._on_dork_item_changed)
+        self.lst_dorks.itemDoubleClicked.connect(self._on_edit_dork)
+        self.txt_preview.textEdited.connect(self._on_preview_edited)
 
     def _wire_vm(self) -> None:
         self._vm.categories_changed.connect(self._on_categories_changed)
@@ -132,3 +136,20 @@ class MainWindow(QMainWindow):
     def _on_dork_item_changed(self, item) -> None:
         idx = self.lst_dorks.row(item)
         self._vm.set_dork_checked(idx, item.checkState() == Qt.Checked)
+
+    @Slot()
+    def _on_add_clicked(self) -> None:
+        text, ok = QInputDialog.getText(self, "Add Dork", "Enter dork:")
+        if ok and text.strip():
+            self._vm.add_dork(text)
+
+    @Slot("QListWidgetItem*")
+    def _on_edit_dork(self, item) -> None:
+        idx = self.lst_dorks.row(item)
+        text, ok = QInputDialog.getText(self, "Edit Dork", "Update dork:", text=item.text())
+        if ok and text.strip():
+            self._vm.edit_dork(idx, text)
+
+    @Slot(str)
+    def _on_preview_edited(self, text: str) -> None:
+        self._vm.set_query_text(text)

--- a/osint_dork_builder/dork_builder/ui/viewmodels.py
+++ b/osint_dork_builder/dork_builder/ui/viewmodels.py
@@ -3,6 +3,7 @@ from PySide6.QtCore import QObject, Signal, Slot
 from typing import List, Dict, Set
 from dork_builder.core.models import DorkCategory
 from dork_builder.core.query_builder import QueryBuilder
+from dork_builder.core.repository import DorkRepository
 
 class AppViewModel(QObject):
     query_changed = Signal(str)
@@ -10,13 +11,15 @@ class AppViewModel(QObject):
     current_category_changed = Signal(object)  # DorkCategory
     dork_checks_changed = Signal(set)
 
-    def __init__(self, categories: List[DorkCategory]) -> None:
+    def __init__(self, repo: DorkRepository) -> None:
         super().__init__()
-        self._categories = categories
-        self._cat_by_key: Dict[str, DorkCategory] = {c.key: c for c in categories}
-        self._current_key: str | None = categories[0].key if categories else None
+        self._repo = repo
+        self._categories = repo.load()
+        self._cat_by_key: Dict[str, DorkCategory] = {c.key: c for c in self._categories}
+        self._current_key: str | None = self._categories[0].key if self._categories else None
         self._checked: Set[int] = set()
         self._builder = QueryBuilder()
+        self._manual_query: str | None = None
 
     def initialize(self) -> None:
         """Emit initial state signals."""
@@ -25,7 +28,10 @@ class AppViewModel(QObject):
             self.current_category_changed.emit(self._cat_by_key[self._current_key])
 
     def _emit_query(self) -> None:
-        self.query_changed.emit(self._builder.build())
+        if self._manual_query is not None:
+            self.query_changed.emit(self._manual_query)
+        else:
+            self.query_changed.emit(self._builder.build())
 
     @Slot(str)
     def set_current_category(self, key: str) -> None:
@@ -33,6 +39,7 @@ class AppViewModel(QObject):
             self._current_key = key
             self._checked.clear()
             self._builder.clear()
+            self._manual_query = None
             self.current_category_changed.emit(self._cat_by_key[key])
             self.dork_checks_changed.emit(set())
             self._emit_query()
@@ -54,5 +61,40 @@ class AppViewModel(QObject):
         self._builder.clear()
         tokens = [cat.items[i] for i in sorted(self._checked)]
         self._builder.extend(tokens)
+        self._manual_query = None
         self.dork_checks_changed.emit(set(self._checked))
         self._emit_query()
+
+    @Slot(str)
+    def set_query_text(self, text: str) -> None:
+        self._manual_query = text
+        self._emit_query()
+
+    @Slot(str)
+    def add_dork(self, text: str) -> None:
+        if self._current_key is None:
+            return
+        text = text.strip()
+        if not text:
+            return
+        cat = self._cat_by_key[self._current_key]
+        cat.items.append(text)
+        self._repo.save(self._categories)
+        self.current_category_changed.emit(cat)
+
+    @Slot(int, str)
+    def edit_dork(self, index: int, text: str) -> None:
+        if self._current_key is None:
+            return
+        cat = self._cat_by_key[self._current_key]
+        text = text.strip()
+        if not (0 <= index < len(cat.items)) or not text:
+            return
+        cat.items[index] = text
+        if index in self._checked:
+            self._builder.clear()
+            tokens = [cat.items[i] for i in sorted(self._checked)]
+            self._builder.extend(tokens)
+            self._emit_query()
+        self._repo.save(self._categories)
+        self.current_category_changed.emit(cat)


### PR DESCRIPTION
## Summary
- add repository save capability
- allow adding and editing custom dorks
- make query preview editable and save manual queries

## Testing
- `python -m pip install -r osint_dork_builder/requirements.txt`
- `python -m py_compile osint_dork_builder/app.py osint_dork_builder/dork_builder/core/repository.py osint_dork_builder/dork_builder/ui/viewmodels.py osint_dork_builder/dork_builder/ui/main_window.py`


------
https://chatgpt.com/codex/tasks/task_e_689f2d2e38ac8327994bf7f8957f33ac