### PR TITLE
Prevent duplicate dorks

### DIFF
--- a/osint_dork_builder/README.md
+++ b/osint_dork_builder/README.md
@@ -10,3 +10,7 @@ pip install -r requirements.txt
 python app.py
 ```
 
+## Notes
+
+- Adding a dork that already exists is not allowed. The application will warn you if you try to add a duplicate.
+

--- a/osint_dork_builder/dork_builder/ui/main_window.py
+++ b/osint_dork_builder/dork_builder/ui/main_window.py
@@ -93,6 +93,7 @@ class MainWindow(QMainWindow):
         self._vm.current_category_changed.connect(self._on_current_category_changed)
         self._vm.query_changed.connect(self.txt_preview.setText)
         self._vm.dork_checks_changed.connect(self._on_dork_checks_changed)
+        self._vm.warning.connect(self._on_warning)
 
     def _build_url(self) -> str:
         from urllib.parse import quote_plus
@@ -182,3 +183,7 @@ class MainWindow(QMainWindow):
         text, ok = QInputDialog.getText(self, "Edit Dork", "Update dork:", text=item.text())
         if ok and text.strip():
             self._vm.edit_dork(idx, text)
+
+    @Slot(str)
+    def _on_warning(self, msg: str) -> None:
+        QMessageBox.warning(self, "Warning", msg)

--- a/osint_dork_builder/dork_builder/ui/viewmodels.py
+++ b/osint_dork_builder/dork_builder/ui/viewmodels.py
@@ -10,6 +10,7 @@ class AppViewModel(QObject):
     categories_changed = Signal(list)
     current_category_changed = Signal(object)  # DorkCategory
     dork_checks_changed = Signal(set)
+    warning = Signal(str)
 
     def __init__(self, repo: DorkRepository) -> None:
         super().__init__()
@@ -67,6 +68,9 @@ class AppViewModel(QObject):
         if not text:
             return
         cat = self._cat_by_key[self._current_key]
+        if text in cat.items:
+            self.warning.emit("Dork already exists.")
+            return
         cat.items.append(text)
         self._repo.save(self._categories)
         self.current_category_changed.emit(cat)


### PR DESCRIPTION
## Summary
- disallow adding duplicate dorks and warn the user
- inform users in README that duplicates aren't allowed

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f3f5d62f08327ae0456cddce28083