### PR TITLE
feat: load settings from file or environment

### DIFF
--- a/osint_dork_builder/app.py
+++ b/osint_dork_builder/app.py
@@ -1,16 +1,17 @@
 from __future__ import annotations
 import sys
 from PySide6.QtWidgets import QApplication
-from dork_builder.config.settings import SETTINGS
+from dork_builder.config.settings import Settings
 from dork_builder.core.repository import DorkRepository
 from dork_builder.ui.viewmodels import AppViewModel
 from dork_builder.ui.main_window import MainWindow
 
 def main() -> int:
     app = QApplication(sys.argv)
-    repo = DorkRepository(SETTINGS.dorks_json_path)
+    settings = Settings.from_env()
+    repo = DorkRepository(settings.dorks_json_path)
     vm = AppViewModel(repo)
-    win = MainWindow(vm)
+    win = MainWindow(vm, settings.open_in_browser)
     win.show()
     return app.exec()
 

--- a/osint_dork_builder/dork_builder/config/settings.py
+++ b/osint_dork_builder/dork_builder/config/settings.py
@@ -1,10 +1,68 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
+import json
+import os
+
 
 @dataclass(frozen=True)
 class Settings:
+    """Application configuration values.
+
+    Defaults are chosen to match previous hard coded behaviour but the class
+    can now build an instance from a ``settings.json`` file and/or environment
+    variables.
+    """
+
     dorks_json_path: Path = Path("boxpiper_google_dorks.json")
     open_in_browser: bool = True
 
-SETTINGS = Settings()
+    @classmethod
+    def from_file(cls, path: Path | str = Path("settings.json")) -> "Settings":
+        """Create ``Settings`` reading values from *path* if it exists.
+
+        Any missing values fall back to the class defaults.
+        """
+
+        defaults = cls()
+        cfg_path = Path(path)
+        if not cfg_path.exists():
+            return defaults
+
+        data = json.loads(cfg_path.read_text() or "{}")
+        return cls(
+            dorks_json_path=Path(
+                data.get("dorks_json_path", defaults.dorks_json_path)
+            ),
+            open_in_browser=data.get("open_in_browser", defaults.open_in_browser),
+        )
+
+    @classmethod
+    def from_env(cls, path: Path | str = Path("settings.json")) -> "Settings":
+        """Create ``Settings`` using environment variables.
+
+        ``DORKS_JSON_PATH`` and ``OPEN_IN_BROWSER`` override values loaded from
+        ``settings.json``.  Environment variables are parsed conservatively so
+        any unrecognised value falls back to the file/default setting.
+        """
+
+        base = cls.from_file(path)
+        json_path = os.getenv("DORKS_JSON_PATH")
+        open_in_browser = os.getenv("OPEN_IN_BROWSER")
+
+        if json_path:
+            dorks_path = Path(json_path)
+        else:
+            dorks_path = base.dorks_json_path
+
+        if open_in_browser is None:
+            open_browser = base.open_in_browser
+        else:
+            open_browser = open_in_browser.lower() in {"1", "true", "yes", "on"}
+
+        return cls(dorks_json_path=dorks_path, open_in_browser=open_browser)
+
+
+# Convenience accessor preserving previous ``SETTINGS`` style usage.
+SETTINGS = Settings.from_env()
+

--- a/osint_dork_builder/dork_builder/ui/main_window.py
+++ b/osint_dork_builder/dork_builder/ui/main_window.py
@@ -10,12 +10,18 @@ from dork_builder.core.models import DorkCategory
 from dork_builder.core.commands import OpenInBrowserCommand, NoopCommand
 from .viewmodels import AppViewModel
 
+
 class MainWindow(QMainWindow):
-    def __init__(self, vm: AppViewModel) -> None:
+    def __init__(self, vm: AppViewModel, open_in_browser: bool = True) -> None:
         super().__init__()
         self.setWindowTitle("OSINT Google Dork Builder")
         self.resize(1100, 700)
         self._vm = vm
+        self._open_cmd = (
+            OpenInBrowserCommand(self._build_url)
+            if open_in_browser
+            else NoopCommand()
+        )
         self._setup_ui()
         self._wire_vm()
         self._vm.initialize()
@@ -75,9 +81,6 @@ class MainWindow(QMainWindow):
         act_quit = QAction("Quit", self)
         act_quit.triggered.connect(self.close)
         self.menuBar().addAction(act_quit)
-
-        self._open_cmd = OpenInBrowserCommand(self._build_url)
-        self._noop_cmd = NoopCommand()
 
         self.lst_categories.currentRowChanged.connect(self._on_category_row_changed)
         self.btn_open.clicked.connect(lambda: self._open_cmd())


### PR DESCRIPTION
## Summary
- allow configuration via `settings.json` or environment variables
- load settings in `app.py` and pass to UI
- optionally disable browser launching via new `open_in_browser` flag

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689f3f6bcdbc8327862e05555d4c27c8